### PR TITLE
Avoid array search

### DIFF
--- a/app.js
+++ b/app.js
@@ -240,7 +240,7 @@ function OpenmixApplication(settings) {
     }
 
     /**
-     * @param {Object} object
+     * @param {!Object} object
      */
     function copyToMaps(object) {
         var maps = {},


### PR DESCRIPTION
Generate maps from the geo/asn options to avoid array search during candidate filtering.
