### PR TITLE
Added quantil

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,18 +3,21 @@ var handler = new OpenmixApplication({
         'cloudflare': 'cdn.jsdelivr.net.cdn.cloudflare.net',
         'maxcdn': 'jsdelivr3.dak.netdna-cdn.com',
         'tm-mg': 'tm-mg.jsdelivr.net',
-        'keycdn': 'jsdelivr-cb7.kxcdn.com'
+        'keycdn': 'jsdelivr-cb7.kxcdn.com',
+        'quantil': 'cdn.jsdelivr.net.mwcloudcdn.com'
     },
     // Use countryMapping to give consideration to additional providers for
     // specific countries:
     countryMapping: {
-        'MG': [ 'tm-mg', 'maxcdn', 'cloudflare', 'keycdn' ]
+        'MG': [ 'tm-mg', 'maxcdn', 'cloudflare', 'keycdn' ],
+        'CN': [ 'quantil'],
+        'TH': [ 'maxcdn', 'cloudflare', 'keycdn', 'quantil']
     },
-    defaultProviders: [ 'maxcdn', 'cloudflare', 'keycdn'  ],
+    defaultProviders: [ 'maxcdn', 'cloudflare', 'keycdn' ],
     lastResortProvider: 'maxcdn',
     defaultTtl: 20,
     availabilityThresholds: {
-        normal: 92
+        normal: 93
     },
     sonarThreshold: 0.95
 });


### PR DESCRIPTION
Removed others from China because only Quantil has servers there and we dont have enough RUM tests from China to do correct load-balancing based on performance.
If Quantil goes down it will failover to MaxCDN automatically.